### PR TITLE
Do not call callbacks on a destroyed object.

### DIFF
--- a/addon/mixins/query-params.js
+++ b/addon/mixins/query-params.js
@@ -47,6 +47,10 @@ export default Ember.Mixin.create({
       return all;
     }, []);
     let update = (name, val) => {
+      if (context.isDestroyed || context.isDestroying) {
+        return;
+      }
+      
       Ember.run(context, 'set', name, val);
     };
 


### PR DESCRIPTION
Using `autoSubscribe` could potentially make the callbacks get called on a destroyed object.
