### PR TITLE
Fix deserialization of array

### DIFF
--- a/addon/mixins/autosubscribe.js
+++ b/addon/mixins/autosubscribe.js
@@ -67,7 +67,7 @@ export default Ember.Mixin.create({
 });
 
 function normalizeArrayQp(val) {
-  var matched = val && val.match(/^"(\[.*,*\])"$/)
+  var matched = val && val.match(/^"(\[.*,*\])"$/);
   if (matched) {
     try {
       return JSON.parse(matched[1]);

--- a/addon/mixins/autosubscribe.js
+++ b/addon/mixins/autosubscribe.js
@@ -67,9 +67,10 @@ export default Ember.Mixin.create({
 });
 
 function normalizeArrayQp(val) {
-  if (val && val.match(/^"\[.*,*\]"$/)) {
+  var matched = val && val.match(/^"(\[.*,*\])"$/)
+  if (matched) {
     try {
-      return JSON.parse(val);
+      return JSON.parse(matched[1]);
     } catch(e) {}
   }
 


### PR DESCRIPTION
normalizeArrayQP should return an array.

before:
`""[\"blah\"]""` would return `""["blah"]""`

after
`""[\"blah\"]""` would return `["blah"]`